### PR TITLE
rU deprecated

### DIFF
--- a/snakefiles/GAP_sort_scaffolds_by_hic_insert2
+++ b/snakefiles/GAP_sort_scaffolds_by_hic_insert2
@@ -356,7 +356,7 @@ rule summarize_matrix_by_chromosome_coordinate:
     run:
         # first, get the scaffold to size
         scaf_to_size = {}
-        with open(input.assem, "rU") as handle:
+        with open(input.assem, "r", newline="") as handle:
             for record in SeqIO.parse(handle, "fasta"):
                 scaf_to_size[record.id] = len(record.seq)
 
@@ -594,7 +594,7 @@ rule output_sorted_fasta:
         chromosome_dict  = {}
         scaffold_dict    = {}
         scaffold_order   = []
-        with open(input.assem, "rU") as handle:
+        with open(input.assem, "r", newline="") as handle:
             for record in SeqIO.parse(handle, "fasta"):
                 if record.id in config["chromosomes"]:
                     unseen_chromosomes.remove(str(record.id))


### PR DESCRIPTION
apparently universal newlines ("rU" mode) is deprecated since 3.5 [according to the documentation](https://docs.python.org/3.5/library/functions.html#open). It's supposed to be handled with `newline=''` instead (see [StackOverflow](https://stackoverflow.com/questions/38093326/whats-the-difference-between-rb-and-ru-in-the-open-function-for-csv) as well)